### PR TITLE
[SPE-1150] Add language config field type

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,15 @@ type LanguageConfig struct {
 	Cfg     map[string]any `yaml:",inline"`
 }
 
+type LanguageConfigField struct {
+	Name              string  `yaml:"name" json:"name"`
+	Required          bool    `yaml:"required" json:"required"`
+	DefaultValue      *string `yaml:"defaultValue,omitempty" json:"default_value,omitempty"`
+	Description       *string `yaml:"description,omitempty" json:"description,omitempty"`
+	ValidationRegex   *string `yaml:"validationRegex,omitempty" json:"validation_regex,omitempty"`
+	ValidationMessage *string `yaml:"validationMessage,omitempty" json:"validation_message,omitempty"`
+}
+
 type Config struct {
 	ConfigVersion string                    `yaml:"configVersion"`
 	Management    *Management               `yaml:"management,omitempty"`


### PR DESCRIPTION
This is in service of additional PRs ([here](https://github.com/speakeasy-api/openapi-generation/pull/147)) in order to power "data driven" frontend 