### PR TITLE
fix: file status function

### DIFF
--- a/workflow/common.go
+++ b/workflow/common.go
@@ -1,9 +1,10 @@
 package workflow
 
 import (
-	"errors"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type fileStatus int
@@ -15,14 +16,32 @@ const (
 )
 
 func getFileStatus(filePath string) fileStatus {
-	_, err := url.ParseRequestURI(filePath)
-	if err != nil {
-		if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
-			return fileStatusNotExists
-		}
-
+	if _, err := os.Stat(sanitizeFilePath(filePath)); err == nil {
 		return fileStatusLocal
 	}
 
-	return fileStatusRemote
+	if _, err := url.ParseRequestURI(filePath); err == nil {
+		return fileStatusRemote
+	}
+
+	return fileStatusNotExists
+}
+
+func sanitizeFilePath(path string) string {
+	sanitizedPath := path
+	if strings.HasPrefix(path, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+
+		sanitizedPath = filepath.Join(homeDir, path[2:])
+		if absPath, err := filepath.Abs(sanitizedPath); err == nil {
+			sanitizedPath = absPath
+		}
+
+		return sanitizedPath
+	}
+
+	return sanitizedPath
 }

--- a/workflow/common.go
+++ b/workflow/common.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,7 +17,7 @@ const (
 )
 
 func getFileStatus(filePath string) fileStatus {
-	if _, err := os.Stat(sanitizeFilePath(filePath)); err == nil {
+	if _, err := os.Stat(sanitizeFilePath(filePath)); err == nil || !errors.Is(err, os.ErrNotExist) {
 		return fileStatusLocal
 	}
 

--- a/workflow/common.go
+++ b/workflow/common.go
@@ -17,7 +17,7 @@ const (
 )
 
 func getFileStatus(filePath string) fileStatus {
-	if _, err := os.Stat(sanitizeFilePath(filePath)); err == nil || !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(SanitizeFilePath(filePath)); err == nil || !errors.Is(err, os.ErrNotExist) {
 		return fileStatusLocal
 	}
 
@@ -28,7 +28,7 @@ func getFileStatus(filePath string) fileStatus {
 	return fileStatusNotExists
 }
 
-func sanitizeFilePath(path string) string {
+func SanitizeFilePath(path string) string {
 	sanitizedPath := path
 	if strings.HasPrefix(path, "~/") {
 		homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
We were not handling paths correctly that are formatted like the following
`~/speakeasy/openapi.yaml`
`/Users/ryanalbert/speakeasy/openapi.yaml`

This is because ~ breaks os.Stat even if you are using filepath.Abs. You need to actually replace the ~ with the UserHomeDir.

The ordering of the getFileStatus function was also problematic. A path like `/Users/ryanalbert/speakeasy/openapi.yaml` does not error on ParseRequestURI so we were recognizing it as a remote URL.