### PR TITLE
chore: update source model for registry

### DIFF
--- a/workflow/source.go
+++ b/workflow/source.go
@@ -61,10 +61,6 @@ func (s Source) GetOutputLocation() (string, error) {
 			return "", fmt.Errorf("when merging multiple inputs, output must be a yaml file")
 		}
 
-		if (len(s.Inputs) == 0 || (len(s.Inputs) == 1 && output != s.Inputs[0].Location)) && len(s.Overlays) == 0 {
-			return "", fmt.Errorf("when using a single input, output should not be specified")
-		}
-
 		return output, nil
 	}
 

--- a/workflow/source_test.go
+++ b/workflow/source_test.go
@@ -90,20 +90,6 @@ func TestSource_Validate(t *testing.T) {
 			wantErr: fmt.Errorf("failed to get output location: input file openapi.yaml does not exist"),
 		},
 		{
-			name: "simple source fails if output is set to a different value when no modifications will be made",
-			args: args{
-				source: workflow.Source{
-					Inputs: []workflow.Document{
-						{
-							Location: "openapi.yaml",
-						},
-					},
-					Output: pointer.ToString("openapi_out.yaml"),
-				},
-			},
-			wantErr: fmt.Errorf("failed to get output location: when using a single input, output should not be specified"),
-		},
-		{
 			name: "source with multiple documents successfully validates",
 			args: args{
 				source: workflow.Source{
@@ -256,6 +242,51 @@ func TestSource_Validate(t *testing.T) {
 				},
 			},
 			wantErr: fmt.Errorf("failed to validate overlay 0: location is required"),
+		},
+		{
+			name: "publish success",
+			args: args{
+				source: workflow.Source{
+					Inputs: []workflow.Document{
+						{
+							Location: "openapi.yaml",
+						},
+					},
+					Publish: &workflow.Publish{
+						Location: "speakeasy://org/workspace/image",
+					},
+				},
+			},
+		},
+		{
+			name: "publish fails with invalid location",
+			args: args{
+				source: workflow.Source{
+					Inputs: []workflow.Document{
+						{
+							Location: "openapi.yaml",
+						},
+					},
+					Publish: &workflow.Publish{
+						Location: "speakeasy://not-enough-parts",
+					},
+				},
+			},
+			wantErr: fmt.Errorf("failed to validate publish: publish location should look like speakeasy://<org>/<workspace>/<image>"),
+		},
+		{
+			name: "publish fails with no location",
+			args: args{
+				source: workflow.Source{
+					Inputs: []workflow.Document{
+						{
+							Location: "openapi.yaml",
+						},
+					},
+					Publish: &workflow.Publish{},
+				},
+			},
+			wantErr: fmt.Errorf("failed to validate publish: location is required"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds to sources a publish field for pushing to the registry.

It also removes a validation that is unnecessary (I think?) and gets in the way of some of the changes we want to make for the Bundler

For example, it's perfectly valid to have one input spec and set the output to `speakeasy://my-image`
Also, I don't see a reason why someone can't have one input spec and an output like `./output/openapi.yaml`. If they want to move it, then 🤷 