### PR TITLE
feat: utilities for loading registry documents

### DIFF
--- a/workflow/common.go
+++ b/workflow/common.go
@@ -14,9 +14,13 @@ const (
 	fileStatusLocal fileStatus = iota
 	fileStatusNotExists
 	fileStatusRemote
+	fileStatusRegistry
 )
 
 func getFileStatus(filePath string) fileStatus {
+	if strings.Contains(filePath, "registry.speakeasyapi.dev") {
+		return fileStatusRegistry
+	}
 	if _, err := os.Stat(SanitizeFilePath(filePath)); err == nil || !errors.Is(err, os.ErrNotExist) {
 		return fileStatusLocal
 	}

--- a/workflow/source.go
+++ b/workflow/source.go
@@ -179,6 +179,10 @@ func (d Document) GetTempDownloadPath(tempDir string) string {
 	return filepath.Join(tempDir, fmt.Sprintf("downloaded_%s%s", randStringBytes(10), filepath.Ext(d.Location)))
 }
 
+func (d Document) GetTempRegistryDir(tempDir string) string {
+	return filepath.Join(tempDir, fmt.Sprintf("registry_%s", randStringBytes(10)))
+}
+
 const namespacePrefix = "@"
 
 func (p SourcePublishing) Validate() error {

--- a/workflow/source.go
+++ b/workflow/source.go
@@ -152,7 +152,7 @@ func (d Document) IsSpeakeasyRegistry() bool {
 	return strings.Contains(d.Location, "registry.speakeasyapi.dev")
 }
 
-func (d Document) ParseSpeakeasyRegistry() *SpeakeasyRegistryDocument {
+func (d Document) ParseSpeakeasyRegistryReference() *SpeakeasyRegistryDocument {
 	if !d.IsSpeakeasyRegistry() {
 		return nil
 	}

--- a/workflow/source.go
+++ b/workflow/source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -149,25 +150,22 @@ func (d Document) IsSpeakeasyRegistry() bool {
 	return strings.Contains(d.Location, "registry.speakeasyapi.dev")
 }
 
-func (d Document) ParseSpeakeasyRegistryReference() *SpeakeasyRegistryDocument {
-	if !d.IsSpeakeasyRegistry() {
-		return nil
-	}
-
+// ParseSpeakeasyRegistryReference Exposed utility that can be used outside of purely documents
+func ParseSpeakeasyRegistryReference(location string) *SpeakeasyRegistryDocument {
 	registryDocument := &SpeakeasyRegistryDocument{}
-	path := strings.Split(d.Location, "registry.speakeasyapi.dev/")[1]
+	subPath := strings.Split(location, "registry.speakeasyapi.dev/")[1]
 	// Attempt to split the reference for a revision @sha256:...
-	components := strings.SplitN(path, "@sha256", 1)
+	components := strings.SplitN(subPath, "@sha256", 2)
 	if len(components) == 2 {
-		registryDocument.NamespaceID = components[0]
+		registryDocument.NamespaceID = path.Base(components[0])
 		registryDocument.Reference = "sha256" + components[1]
 	} else {
-		components = strings.SplitN(path, ":", 1)
+		components = strings.SplitN(subPath, ":", 2)
 		if len(components) == 2 {
-			registryDocument.NamespaceID = components[0]
+			registryDocument.NamespaceID = path.Base(components[0])
 			registryDocument.Reference = components[1]
 		} else { // no tag or revision was found default to latest
-			registryDocument.NamespaceID = strings.TrimSuffix(path, "/")
+			registryDocument.NamespaceID = path.Base(strings.TrimSuffix(subPath, "/"))
 			registryDocument.Reference = "latest"
 		}
 	}


### PR DESCRIPTION
Sets up some utility functions we will need when loading registry documents. These could be used by speakeasy-core, speakeasy-registry, or speakeasy (CLI)

- Determines whether an input document is a registry reference
- Parses a registry reference URL into relevant OCI components we will need when loading the document orgSlug, workspaceSlug, namespaceName, reference