### PR TITLE
fix: remove unused methodSignaturesApr2024 flag

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -42,7 +42,6 @@ type Fixes struct {
 	NameResolutionDec2023                bool           `yaml:"nameResolutionDec2023"`
 	ParameterOrderingFeb2024             bool           `yaml:"parameterOrderingFeb2024"`
 	RequestResponseComponentNamesFeb2024 bool           `yaml:"requestResponseComponentNamesFeb2024"`
-	MethodSignaturesApr2024              bool           `yaml:"methodSignaturesApr2024"`
 	AdditionalProperties                 map[string]any `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
 }
 

--- a/io_test.go
+++ b/io_test.go
@@ -56,7 +56,6 @@ func TestLoad_Success(t *testing.T) {
 							NameResolutionDec2023:                true,
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
-							MethodSignaturesApr2024:              true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,
@@ -267,7 +266,6 @@ func TestLoad_Success(t *testing.T) {
 							NameResolutionDec2023:                true,
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
-							MethodSignaturesApr2024:              true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,
@@ -318,7 +316,6 @@ func TestLoad_Success(t *testing.T) {
 							NameResolutionDec2023:                true,
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
-							MethodSignaturesApr2024:              true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,


### PR DESCRIPTION
We decided to instead make this a target-level config flag.