### PR TITLE
fix: Use 0666 file mode for writing configuration and lock files

### DIFF
--- a/io.go
+++ b/io.go
@@ -421,7 +421,7 @@ func write(path string, cfg any, o *options) ([]byte, error) {
 		writeFileFunc = o.FS.WriteFile
 	}
 
-	if err := writeFileFunc(path, data, os.ModePerm); err != nil {
+	if err := writeFileFunc(path, data, 0666); err != nil {
 		return nil, fmt.Errorf("could not write gen.yaml: %w", err)
 	}
 


### PR DESCRIPTION
Reference: https://gist.github.com/jamietanna/65bd5b8229efebc8ee1e176434615495

Previously, files were written with the 0777 file mode. On most systems with 022 umask they would be written with the execution bits enabled, which is unnecessary for text files.

```console
❯ speakeasy quickstart
❯ ls -la OUTDIR/.speakeasy
total 40
drwxr-xr-x@  6 bflad  staff   192 Jul  5 14:25 .
drwxr-xr-x@ 17 bflad  staff   544 Jul  5 14:32 ..
-rwxr-xr-x@  1 bflad  staff  4801 Jul  5 14:25 gen.lock
-rwxr-xr-x@  1 bflad  staff   584 Jul  5 14:25 gen.yaml
-rw-r--r--@  1 bflad  staff  1062 Jul  5 14:25 workflow.lock
-rw-r--r--@  1 bflad  staff   301 Jul  5 14:26 workflow.yaml
```

This change sets the file mode to 0666 and adds verification unit testing for the final saved file permissions. If the testing ever becomes platform dependently flakey, the umask can be explicitly set in the unit testing.