### PR TITLE
feat: Add gen.yaml generation.mockServer configuration

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -62,6 +62,9 @@ type Generation struct {
 	Fixes                       *Fixes         `yaml:"fixes,omitempty"`
 	Auth                        *Auth          `yaml:"auth,omitempty"`
 
+	// Mock server generation configuration.
+	MockServer *MockServer `yaml:"mockServer,omitempty"`
+
 	AdditionalProperties map[string]any `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
 }
 
@@ -70,6 +73,12 @@ type DevContainers struct {
 	// This can be a local path or a remote URL
 	SchemaPath           string         `yaml:"schemaPath"`
 	AdditionalProperties map[string]any `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
+}
+
+// Generation configuration for the inter-templated mockserver target for test generation.
+type MockServer struct {
+	// Disables the code generation of the mockserver target.
+	Disabled bool `yaml:"disabled"`
 }
 
 type LanguageConfig struct {


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/SPE-4016/feature-add-mockserver-generation-configuration-flag
Reference: https://linear.app/speakeasy/issue/SPE-4011/feature-enable-mockserver-generation-for-customers

Introduces a new `mockServer` configuration object under the `generation` object that will be used to configure generation settings for the mock server that will be eventually bundled with test generation. While the mock server is under development, the generator will explicitly look for the `MockServer` configuration object to be present and `disabled` to be `false`. When we want to enable mock server generation for customers, we will update that logic to treat missing `MockServer` as "enabled" or if the object is present, respect the `disabled` flag (effectively making it opt-out).