### PR TITLE
chore: remove outputLocation from workflow.lock

### DIFF
--- a/workflow/lockfile.go
+++ b/workflow/lockfile.go
@@ -36,7 +36,6 @@ type TargetLock struct {
 	CodeSamplesNamespace      string `yaml:"codeSamplesNamespace,omitempty"`
 	CodeSamplesRevisionDigest string `yaml:"codeSamplesRevisionDigest,omitempty"`
 	CodeSamplesBlobDigest     string `yaml:"codeSamplesBlobDigest,omitempty"`
-	OutLocation               string `yaml:"outLocation,omitempty"`
 }
 
 func LoadLockfile(dir string) (*LockFile, error) {


### PR DESCRIPTION
This is unused.