### PR TITLE
feat: tracking generation time and workflow dispatch in publishing

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -114,12 +114,13 @@ type PublishWorkflow struct {
 }
 
 type PublishOn struct {
-	Push Push `yaml:"push"`
+	Push             Push                  `yaml:"push"`
+	WorkflowDispatch WorkflowDispatchEmpty `yaml:"workflow_dispatch"`
 }
 
 type TagOn struct {
-	Push             Push                    `yaml:"push"`
-	WorkflowDispatch WorkflowDispatchTagging `yaml:"workflow_dispatch"`
+	Push             Push                  `yaml:"push"`
+	WorkflowDispatch WorkflowDispatchEmpty `yaml:"workflow_dispatch"`
 }
 
 type Push struct {
@@ -169,7 +170,7 @@ type WorkflowDispatch struct {
 	Inputs Inputs `yaml:"inputs"`
 }
 
-type WorkflowDispatchTagging struct{}
+type WorkflowDispatchEmpty struct{}
 
 type Schedule struct {
 	Cron string `yaml:"cron"`

--- a/lockfile.go
+++ b/lockfile.go
@@ -21,6 +21,7 @@ type Management struct {
 	DocVersion           string         `yaml:"docVersion,omitempty"`
 	SpeakeasyVersion     string         `yaml:"speakeasyVersion,omitempty"`
 	GenerationVersion    string         `yaml:"generationVersion,omitempty"`
+	GenerationTime       string         `yaml:"generationTime,omitempty"`
 	ReleaseVersion       string         `yaml:"releaseVersion,omitempty"`
 	ConfigChecksum       string         `yaml:"configChecksum,omitempty"`
 	RepoURL              string         `yaml:"repoURL,omitempty"`

--- a/lockfile.go
+++ b/lockfile.go
@@ -21,7 +21,7 @@ type Management struct {
 	DocVersion           string         `yaml:"docVersion,omitempty"`
 	SpeakeasyVersion     string         `yaml:"speakeasyVersion,omitempty"`
 	GenerationVersion    string         `yaml:"generationVersion,omitempty"`
-	GenerationTime       string         `yaml:"generationTime,omitempty"`
+	GenerationTimestamp  string         `yaml:"generationTimestamp,omitempty"`
 	ReleaseVersion       string         `yaml:"releaseVersion,omitempty"`
 	ConfigChecksum       string         `yaml:"configChecksum,omitempty"`
 	RepoURL              string         `yaml:"repoURL,omitempty"`


### PR DESCRIPTION
Tracking time of generation in gen.lock may be useful for GH actions usecases