### PR TITLE
feat: Introduce featuresAvailable into gen.lock

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -7,13 +7,20 @@ import (
 )
 
 type LockFile struct {
-	LockVersion          string                       `yaml:"lockVersion"`
-	ID                   string                       `yaml:"id"`
-	Management           Management                   `yaml:"management"`
-	Features             map[string]map[string]string `yaml:"features,omitempty"`
-	GeneratedFiles       []string                     `yaml:"generatedFiles,omitempty"`
-	Examples             Examples                     `yaml:"examples,omitempty"`
-	AdditionalProperties map[string]any               `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
+	LockVersion    string     `yaml:"lockVersion"`
+	ID             string     `yaml:"id"`
+	Management     Management `yaml:"management"`
+	GeneratedFiles []string   `yaml:"generatedFiles,omitempty"`
+	Examples       Examples   `yaml:"examples,omitempty"`
+
+	// Mapping of targets to used feature names and versions
+	Features map[string]map[string]string `yaml:"features,omitempty"`
+
+	// Mapping of targets to available feature names and versions
+	FeaturesAvailable map[string]map[string]string `yaml:"featuresAvailable,omitempty"`
+
+	// Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
+	AdditionalProperties map[string]any `yaml:",inline"`
 }
 
 type Management struct {


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/SPE-4333/regenerate-ast-on-changes-to-availablefeatures

This change adds a new mapping of target-available feature versions to the `gen.lock` file, to augment the currently used target feature versions. This would be used to detect changes to the target itself, such as new features, that should always cause target regeneration instead of potentially loading a cached AST.

Alternatively, this change could be avoided by having an overall, singular "target version" for tracking when any change is made to a target, however the overhead of managing that more global version in addition to the individual feature versions would be quite cumbersome.

Alternatively, this change could be avoided by using the existing features field to store all feature versions instead of only used features, but having the ability to inspect used features helps guide product and customer success decisions. It also would break existing niceties, such as only showing changelog entries relevant for used features.