### PR TITLE
fix: codeSamples migrate NPE

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -168,13 +168,17 @@ func (w Workflow) migrate(telemetryDisabled bool) Workflow {
 				continue
 			}
 
+			codeSamplesRegistry := &SourceRegistry{
+				Location: codeSamplesRegistryLocation(source.Registry.Location),
+			}
+
 			if target.CodeSamples == nil {
 				target.CodeSamples = &CodeSamples{
-					Registry: &SourceRegistry{
-						Location: codeSamplesRegistryLocation(source.Registry.Location),
-					},
+					Registry: codeSamplesRegistry,
 					Blocking: pointer.ToBool(false),
 				}
+			} else if target.CodeSamples.Registry == nil {
+				target.CodeSamples.Registry = codeSamplesRegistry
 			} else {
 				// Fix the registry location if it needs fixing
 				target.CodeSamples.Registry.Location = codeSamplesRegistryUpdatedLocation(w, target.CodeSamples)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -354,6 +354,37 @@ targets:
             registry:
                 location: registry.speakeasyapi.dev/org/workspace/testSource-code-samples
             blocking: false
+`}, {
+		in: `workflowVersion: 1.0.0
+sources:
+  testSource:
+    inputs:
+      - location: ./openapi.yaml
+    registry:
+      location: registry.speakeasyapi.dev/org/workspace/testSource
+targets:
+  typescript:
+    target: typescript
+    source: testSource
+    codeSamples:
+      output: output.yaml
+`,
+		expected: `workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+    testSource:
+        inputs:
+            - location: ./openapi.yaml
+        registry:
+            location: registry.speakeasyapi.dev/org/workspace/testSource
+targets:
+    typescript:
+        target: typescript
+        source: testSource
+        codeSamples:
+            output: output.yaml
+            registry:
+                location: registry.speakeasyapi.dev/org/workspace/testSource-code-samples
 `,
 	}}
 


### PR DESCRIPTION
Didn't account for people who already had codeSamples but weren't being pushed to the regsitry