### PR TITLE
feat: Initial workflow target testing configuration

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -168,6 +168,9 @@
         },
         "codeSamples": {
           "$ref": "#/$defs/codeSamples"
+        },
+        "testing": {
+          "$ref": "#/$defs/testing"
         }
       },
       "required": ["target", "source"]
@@ -345,6 +348,30 @@
           "required": ["apiKey"]
         }
       }
+    },
+    "testing": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Target testing configuration. By default, targets are not tested as part of the workflow.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Defaults to false. If true, the target will be tested as part of the workflow."
+        },
+        "mockServer": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Mock API server configuration for testing. By default and if generated, the mock API server is started before testing and used.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Defaults to true. If false, the mock API server will not be started."
+            }
+          },
+          "required": []
+        }
+      },
+      "required": []
     }
   }
 }

--- a/workflow/target.go
+++ b/workflow/target.go
@@ -13,6 +13,25 @@ type Target struct {
 	Output      *string      `yaml:"output,omitempty"`
 	Publishing  *Publishing  `yaml:"publish,omitempty"`
 	CodeSamples *CodeSamples `yaml:"codeSamples,omitempty"`
+
+	// Configuration for target testing. By default, target testing is disabled.
+	Testing *Testing `yaml:"testing,omitempty"`
+}
+
+// Configuration for target testing, such as `go test` for Go targets.
+type Testing struct {
+	// When enabled, the target will be tested as part of the workflow.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// Configuration for mockserver handling during testing. By default, the
+	// mockserver is enabled.
+	MockServer *MockServer `yaml:"mockServer,omitempty"`
+}
+
+// Configuration for mockserver handling during testing.
+type MockServer struct {
+	// When enabled, the mockserver will be started during testing.
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 type Publishing struct {

--- a/workflow/target_test.go
+++ b/workflow/target_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/AlekSi/pointer"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,6 +65,37 @@ func TestTarget_Validate(t *testing.T) {
 					Publishing: &workflow.Publishing{
 						NPM: &workflow.NPM{
 							Token: "$TEST_TOKEN",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "target with testing successfully validates",
+			args: args{
+				supportedLangs: []string{"typescript"},
+				target: workflow.Target{
+					Target: "typescript",
+					Source: "openapi.yaml",
+					Testing: &workflow.Testing{
+						Enabled: pointer.ToBool(true),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "target with testing.mockServer successfully validates",
+			args: args{
+				supportedLangs: []string{"typescript"},
+				target: workflow.Target{
+					Target: "typescript",
+					Source: "openapi.yaml",
+					Testing: &workflow.Testing{
+						Enabled: pointer.ToBool(true),
+						MockServer: &workflow.MockServer{
+							Enabled: pointer.ToBool(false),
 						},
 					},
 				},

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -2,11 +2,13 @@ package workflow_test
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/AlekSi/pointer"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +56,46 @@ targets:
 					"typescript": {
 						Target: "typescript",
 						Source: "testSource",
+					},
+				},
+			},
+		},
+		{
+			name: "loads workflow file with target testing",
+			args: args{
+				workflowLocation: "test/.speakeasy",
+				workflowContents: `workflowVersion: 1.0.0
+sources:
+  testSource:
+    inputs:
+      - location: "./openapi.yaml"
+targets:
+  typescript:
+    target: typescript
+    source: testSource
+    testing:
+      enabled: true
+`,
+				workingDir: "test",
+			},
+			want: &workflow.Workflow{
+				Version: "1.0.0",
+				Sources: map[string]workflow.Source{
+					"testSource": {
+						Inputs: []workflow.Document{
+							{
+								Location: "./openapi.yaml",
+							},
+						},
+					},
+				},
+				Targets: map[string]workflow.Target{
+					"typescript": {
+						Target: "typescript",
+						Source: "testSource",
+						Testing: &workflow.Testing{
+							Enabled: pointer.ToBool(true),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-590/feature-workflow-configuration-updates-for-target-testing

This change enables the following opt-in workflow configuration so customers can enable target testing via `speakeasy run` and direct/test mode in GitHub Actions:

```yaml
sources:
  SOURCE_NAME:
    inputs:
      - # ...
targets:
  TARGET_NAME:
    source: SOURCE_NAME
    target: TARGET
    testing:
      enabled: true
```