### PR TITLE
feat: default language label for codesamples

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -3,13 +3,14 @@ package workflow
 import (
 	"errors"
 	"fmt"
-	"github.com/AlekSi/pointer"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/AlekSi/pointer"
 
 	"github.com/speakeasy-api/sdk-gen-config/workspace"
 	"gopkg.in/yaml.v3"
@@ -173,9 +174,14 @@ func (w Workflow) migrate(telemetryDisabled bool) Workflow {
 			}
 
 			if target.CodeSamples == nil {
+				// Capitalize the first letter of language
+				sdkLabel := fmt.Sprintf("%s (SDK)", strings.ToUpper(string(target.Target[0]))+target.Target[1:])
 				target.CodeSamples = &CodeSamples{
 					Registry: codeSamplesRegistry,
 					Blocking: pointer.ToBool(false),
+					LabelOverride: &CodeSamplesLabelOverride{
+						FixedValue: &sdkLabel,
+					},
 				}
 			} else if target.CodeSamples.Registry == nil {
 				target.CodeSamples.Registry = codeSamplesRegistry

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -333,9 +333,9 @@ targets:
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/org/workspace/testSource-typescript-code-samples
+            labelOverride:
+                fixedValue: Typescript (SDK)
             blocking: false
-			labelOverride:
-				fixedValue: Typescript (SDK)
 `,
 	}, {
 		name: "doesn't migrate a blocking workflow with a registry location",
@@ -399,6 +399,8 @@ targets:
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/org/workspace/testSource-typescript-code-samples
+            labelOverride:
+                fixedValue: Typescript (SDK)
             blocking: false
 `,
 	}, {

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -334,6 +334,8 @@ targets:
             registry:
                 location: registry.speakeasyapi.dev/org/workspace/testSource-typescript-code-samples
             blocking: false
+			labelOverride:
+				fixedValue: Typescript (SDK)
 `,
 	}, {
 		name: "doesn't migrate a blocking workflow with a registry location",


### PR DESCRIPTION
https://linear.app/speakeasy/issue/SPE-4523/default-to-language-label-for-new-codesamples

Many people using codeSamples for docs want the samples to be labeled as SDK codeSamples such as Go (SDK). The default right now shows up as duplicated operation name which is not super useful. We are only doing this for net new workflows right now.