### PR TITLE
fix: corrected the tranform validation logic

### DIFF
--- a/workflow/source.go
+++ b/workflow/source.go
@@ -315,6 +315,8 @@ type FilterOperationsOptions struct {
 	Exclude    *bool  `yaml:"exclude,omitempty"`
 }
 
+var transformList = []string{"removeUnused", "filterOperations", "cleanup", "format", "normalize"}
+
 func (t Transformation) Validate() error {
 	numNil := 0
 	if t.RemoveUnused != nil {
@@ -326,8 +328,14 @@ func (t Transformation) Validate() error {
 	if t.Cleanup != nil {
 		numNil++
 	}
+	if t.Format != nil {
+		numNil++
+	}
+	if t.Normalize != nil {
+		numNil++
+	}
 	if numNil != 1 {
-		return fmt.Errorf("transformation must have exactly one of removeUnused, filterOperations, or cleanup")
+		return fmt.Errorf("transformation must have exactly one of %s", strings.Join(transformList, ", "))
 	}
 
 	if t.FilterOperations != nil {

--- a/workflow/source_test.go
+++ b/workflow/source_test.go
@@ -344,7 +344,7 @@ func TestSource_Validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: fmt.Errorf("failed to validate transformation 0: transformation must have exactly one of removeUnused, filterOperations, or cleanup"),
+			wantErr: fmt.Errorf("failed to validate transformation 0: transformation must have exactly one of removeUnused, filterOperations, cleanup, format, normalize"),
 		},
 		{
 			name: "transformations filter success",


### PR DESCRIPTION
I missed the actual Validation logic for the transforms in the first PR

This pull request to `workflow/source.go` includes changes to enhance the validation logic for transformations and streamline the codebase. The most important changes include the addition of a new list of transformation types and modifications to the validation method to use this list.

Enhancements to validation logic:

* Added a `transformList` variable containing the transformation types: "removeUnused", "filterOperations", "cleanup", "format", and "normalize".
* Modified the `Validate` method in the `Transformation` struct to include checks for `Format` and `Normalize` fields and updated the error message to use the new `transformList` variable.