### PR TITLE
fix: disable oauth2 hooks by default

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -414,13 +414,13 @@ func GetGenerationDefaults(newSDK bool) []SDKGenConfigField {
 		{
 			Name:         "auth.oAuth2ClientCredentialsEnabled",
 			Required:     false,
-			DefaultValue: ptr(newSDK),
+			DefaultValue: ptr(false),
 			Description:  pointer.To("Enables support for OAuth2 client credentials grant type (Enterprise tier only)"),
 		},
 		{
 			Name:         "auth.oAuth2PasswordEnabled",
 			Required:     false,
-			DefaultValue: ptr(newSDK),
+			DefaultValue: ptr(false),
 			Description:  pointer.To("Enables support for OAuth2 resource owner password credentials grant type (Enterprise tier only)"),
 		},
 		{


### PR DESCRIPTION
For new SDK, both `oAuth2ClientCredentialsEnabled` and  `auth.oAuth2PasswordEnabled` even though ClientCredentials and Oauth2Password hooks cannot be used simultaneously. I suggest we se both to false by default.