### PR TITLE
chore: add flags for controlling SDK init style

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -36,8 +36,16 @@ const (
 	OptionalPropertyRenderingOptionWithExample OptionalPropertyRenderingOption = "withExample"
 )
 
+type SDKInitStyle string
+
+const (
+	SDKInitStyleConstructor SDKInitStyle = "constructor"
+	SDKInitStyleBuilder     SDKInitStyle = "builder"
+)
+
 type UsageSnippets struct {
 	OptionalPropertyRendering OptionalPropertyRenderingOption `yaml:"optionalPropertyRendering"`
+	SDKInitStyle              SDKInitStyle                    `yaml:"sdkInitStyle"`
 	AdditionalProperties      map[string]any                  `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
 }
 
@@ -374,6 +382,12 @@ func GetGenerationDefaults(newSDK bool) []SDKGenConfigField {
 			Required:     false,
 			DefaultValue: ptr(OptionalPropertyRenderingOptionWithExample),
 			Description:  pointer.To("Controls how optional properties are rendered in usage snippets, by default they will be rendered when an example is present in the OpenAPI spec"),
+		},
+		{
+			Name:         "usageSnippets.sdkInitStyle",
+			Required:     false,
+			DefaultValue: ptr(SDKInitStyleConstructor),
+			Description:  pointer.To("Controls how the SDK initialization is depicted in usage snippets, by default it will use the constructor"),
 		},
 		{
 			Name:         "useClassNamesForArrayFields",

--- a/io_test.go
+++ b/io_test.go
@@ -52,6 +52,7 @@ func TestLoad_Success(t *testing.T) {
 						MaintainOpenAPIOrder: true,
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                true,
@@ -102,6 +103,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -154,6 +156,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -211,6 +214,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -267,6 +271,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                true,
@@ -319,6 +324,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                true,
@@ -371,6 +377,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -429,6 +436,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -491,6 +499,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,
@@ -550,6 +559,7 @@ func TestLoad_Success(t *testing.T) {
 						SDKClassName:  "speakeasy",
 						UsageSnippets: &UsageSnippets{
 							OptionalPropertyRendering: "withExample",
+							SDKInitStyle:              "constructor",
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                false,

--- a/io_test.go
+++ b/io_test.go
@@ -56,15 +56,18 @@ func TestLoad_Success(t *testing.T) {
 						},
 						Fixes: &Fixes{
 							NameResolutionDec2023:                true,
+							NameResolutionFeb2025:                true,
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
 							SecurityFeb2025:                      true,
+							SharedErrorComponentsApr2025:         true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,
 							OAuth2PasswordEnabled:          true,
 						},
 						UseClassNamesForArrayFields: true,
+						SDKHooksConfigAccess:        true,
 					},
 					New: map[string]bool{
 						"go": true,
@@ -277,7 +280,9 @@ func TestLoad_Success(t *testing.T) {
 							NameResolutionDec2023:                true,
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
+							NameResolutionFeb2025:                true,
 							SecurityFeb2025:                      true,
+							SharedErrorComponentsApr2025:         true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,
@@ -285,6 +290,7 @@ func TestLoad_Success(t *testing.T) {
 						},
 						MaintainOpenAPIOrder:        true,
 						UseClassNamesForArrayFields: true,
+						SDKHooksConfigAccess:        true,
 					},
 					New: map[string]bool{
 						"go": true,
@@ -331,6 +337,8 @@ func TestLoad_Success(t *testing.T) {
 							ParameterOrderingFeb2024:             true,
 							RequestResponseComponentNamesFeb2024: true,
 							SecurityFeb2025:                      true,
+							SharedErrorComponentsApr2025:         true,
+							NameResolutionFeb2025:                true,
 						},
 						Auth: &Auth{
 							OAuth2ClientCredentialsEnabled: true,
@@ -338,6 +346,7 @@ func TestLoad_Success(t *testing.T) {
 						},
 						MaintainOpenAPIOrder:        true,
 						UseClassNamesForArrayFields: true,
+						SDKHooksConfigAccess:        true,
 					},
 					New: map[string]bool{
 						"go": true,
@@ -673,6 +682,7 @@ func TestLoad_BackwardsCompatibility_Success(t *testing.T) {
 				SDKClassName:  "speakeasy",
 				UsageSnippets: &UsageSnippets{
 					OptionalPropertyRendering: "withExample",
+					SDKInitStyle:              "constructor",
 				},
 				Fixes: &Fixes{
 					NameResolutionDec2023:                false,


### PR DESCRIPTION
Introduces a flag for csharp usage snippets that is referenced in [#2705](https://github.com/speakeasy-api/openapi-generation/pull/2705)