### PR TITLE
feat: Support mcp-typescript in workflow target JSON schema enum

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -147,6 +147,7 @@
             "csharp",
             "go",
             "java",
+            "mcp-typescript",
             "php",
             "python",
             "ruby",


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-1416/feature-initial-mcp-typescript-target-in-sdk-gen-config