### PR TITLE
feat: Add operations information to gen.lock for change reporting

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -16,6 +16,10 @@ type LockFile struct {
 	ExamplesVersion      string                       `yaml:"examplesVersion,omitempty"`
 	GeneratedTests       GeneratedTests               `yaml:"generatedTests,omitempty"`
 	AdditionalProperties map[string]any               `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
+
+	// Mapping of language names to operation identifiers and operation metadata
+	// for change reporting.
+	Operations map[string]map[string]OperationMetadata `yaml:"operations,omitempty"`
 }
 
 type Management struct {
@@ -30,6 +34,36 @@ type Management struct {
 	InstallationURL      string         `yaml:"installationURL,omitempty"`
 	Published            bool           `yaml:"published,omitempty"`
 	AdditionalProperties map[string]any `yaml:",inline"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
+}
+
+// Metadata associated with a single operation for change reporting.
+type OperationMetadata struct {
+	// HTTP method for operation.
+	Method string `yaml:"method"`
+
+	// OpenAPI path for operation. Includes path parameter syntax.
+	Path string `yaml:"path"`
+
+	// Mapping of language-specific representations to representation metadata
+	// for change reporting.
+	//
+	// Representations include native syntax, such as: `sdk.group.Create()`.
+	Representations map[string]OperationRepresentationMetadata `yaml:"representations"`
+
+	// Captures any additional properties that are not explicitly defined for
+	// backwards/forwards compatibility
+	AdditionalProperties map[string]any `yaml:",inline"`
+}
+
+// Metadata associated with a single operation representation for change
+// reporting.
+type OperationRepresentationMetadata struct {
+	// Example future enhancement.
+	// RequiredArguments []string `yaml:"required_arguments,omitempty"`
+
+	// Captures any additional properties that are not explicitly defined for
+	// backwards/forwards compatibility
+	AdditionalProperties map[string]any `yaml:",inline"`
 }
 
 type (


### PR DESCRIPTION
This change adds a `gen.lock` (`LockFile`) type `Operations` field for API and SDK change reporting. This is intentionally a subset of operation data for prioritizing important information to present to API producers and consumers, while not exposing more of the generator internals. This information is intended to be self-contained to prevent the need for the generator or OAS-based tooling when generating API and SDK change reports, e.g. comparing the prior snapshot with a new one should contain everything necessary.

The operation representation metadata can be enhanced over time if additional SDK change reporting, such as new arguments, is desired.
