### PR TITLE
fix: Ensure mcp-typescript implements NPM publishing

### DIFF
--- a/workflow/target.go
+++ b/workflow/target.go
@@ -168,7 +168,7 @@ func (t Target) IsPublished() bool {
 
 func (p Publishing) Validate(target string) error {
 	switch target {
-	case "typescript":
+	case "mcp-typescript", "typescript":
 		if p.NPM != nil && p.NPM.Token != "" {
 			if err := validateSecret(p.NPM.Token); err != nil {
 				return fmt.Errorf("failed to validate npm token: %w", err)
@@ -237,7 +237,7 @@ func (p Publishing) Validate(target string) error {
 
 func (p Publishing) IsPublished(target string) bool {
 	switch target {
-	case "typescript":
+	case "mcp-typescript", "typescript":
 		if p.NPM != nil && p.NPM.Token != "" {
 			return true
 		}

--- a/workflow/target_test.go
+++ b/workflow/target_test.go
@@ -56,11 +56,27 @@ func TestTarget_Validate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "target with publishing successfully validates",
+			name: "typescript target with publishing successfully validates",
 			args: args{
 				supportedLangs: []string{"typescript"},
 				target: workflow.Target{
 					Target: "typescript",
+					Source: "openapi.yaml",
+					Publishing: &workflow.Publishing{
+						NPM: &workflow.NPM{
+							Token: "$TEST_TOKEN",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "mcp-typescript target with publishing successfully validates",
+			args: args{
+				supportedLangs: []string{"mcp-typescript"},
+				target: workflow.Target{
+					Target: "mcp-typescript",
 					Source: "openapi.yaml",
 					Publishing: &workflow.Publishing{
 						NPM: &workflow.NPM{


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-1670/firehydrant-mcp-not-publishing

Properly marks mcp-typescript as published if NPM token is set.