### PR TITLE
feat: union syntax on env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/speakeasy-api/sdk-gen-config
 go 1.24.3
 
 require (
+	github.com/a8m/envsubst v1.4.3
 	github.com/google/uuid v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/speakeasy-api/openapi v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/a8m/envsubst v1.4.3 h1:kDF7paGK8QACWYaQo6KtyYBozY2jhQrTuNNuUxQkhJY=
+github.com/a8m/envsubst v1.4.3/go.mod h1:4jjHWQlZoaXPoLQUb7H2qT4iLkZDdmEQiOUogdUmqVU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/workflow/source.go
+++ b/workflow/source.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/a8m/envsubst"
 	"github.com/speakeasy-api/sdk-gen-config/workspace"
 )
 
@@ -76,33 +77,14 @@ type FallbackCodeSamples struct {
 type LocationString string
 
 func (l LocationString) Resolve() string {
-	if strings.HasPrefix(string(l), "$") {
-		s := string(l)
+	s := string(l)
 
-		// Check for union syntax on env vars: ${var1} || ${var2} || fallback
-		if strings.Contains(s, " || ") {
-			parts := strings.Split(s, " || ")
-
-			for _, part := range parts {
-				part = strings.TrimSpace(part)
-
-				// If it starts with $, try to expand it
-				if strings.HasPrefix(part, "$") {
-					expanded := os.ExpandEnv(part)
-					if expanded != "" {
-						return expanded
-					}
-				} else {
-					// Not a variable, use as literal fallback
-					return part
-				}
-			}
-		}
-
-		return os.ExpandEnv(s)
+	expanded, err := envsubst.String(s)
+	if err != nil {
+		return s
 	}
 
-	return string(l)
+	return expanded
 }
 
 func (l LocationString) Reference() string {

--- a/workflow/source.go
+++ b/workflow/source.go
@@ -77,7 +77,29 @@ type LocationString string
 
 func (l LocationString) Resolve() string {
 	if strings.HasPrefix(string(l), "$") {
-		return os.ExpandEnv(string(l))
+		s := string(l)
+
+		// Check for union syntax on env vars: ${var1} || ${var2} || fallback
+		if strings.Contains(s, " || ") {
+			parts := strings.Split(s, " || ")
+
+			for _, part := range parts {
+				part = strings.TrimSpace(part)
+
+				// If it starts with $, try to expand it
+				if strings.HasPrefix(part, "$") {
+					expanded := os.ExpandEnv(part)
+					if expanded != "" {
+						return expanded
+					}
+				} else {
+					// Not a variable, use as literal fallback
+					return part
+				}
+			}
+		}
+
+		return os.ExpandEnv(s)
 	}
 
 	return string(l)


### PR DESCRIPTION
Supports fallback syntax, and multiple vars:

Name | Env | Value | Want
-- | -- | -- | --
simple substitution | {"SDKGEN_ROOT": "/tmp"} | ${SDKGEN_ROOT}/spec.yaml | /tmp/spec.yaml
fallback substitution | {"SDKGEN_OPTION": ""} | ${SDKGEN_OPTION:-default-value} | default-value
colon plus substitution | {"SDKGEN_FEATURE": "enabled"} | /config${SDKGEN_FEATURE:+/premium} | /config/premium
multiple substitutions | {"SDKGEN_HOST": "api.example.com", "SDKGEN_VERSION": "v1"} | https://${SDKGEN_HOST}/${SDKGEN_VERSION} | https://api.example.com/v1

</div></div><br class="Apple-interchange-newline">