### PR TITLE
feat: add cli target publishing config

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -19,6 +19,21 @@
       ],
       "type": "object"
     },
+    "WorkflowCLI": {
+      "properties": {
+        "gpgPassPhrase": {
+          "type": "string"
+        },
+        "gpgPrivateKey": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "gpgPrivateKey",
+        "gpgPassPhrase"
+      ],
+      "type": "object"
+    },
     "WorkflowCodeSamples": {
       "additionalProperties": false,
       "description": "Code samples configuration. See https://www.speakeasy.com/guides/openapi/x-codesamples",
@@ -292,6 +307,10 @@
       "additionalProperties": false,
       "description": "The publishing configuration. See https://www.speakeasy.com/docs/workflow-reference/publishing-reference",
       "properties": {
+        "cli": {
+          "$ref": "#/$defs/WorkflowCLI",
+          "description": "CLI publishing configuration."
+        },
         "java": {
           "$ref": "#/$defs/WorkflowJava",
           "description": "Maven (Java) publishing configuration."
@@ -446,6 +465,7 @@
         },
         "target": {
           "enum": [
+            "cli",
             "csharp",
             "go",
             "java",

--- a/workflow/target.go
+++ b/workflow/target.go
@@ -9,7 +9,7 @@ import (
 // Ensure you update schema/workflow.schema.json on changes
 type Target struct {
 	_           struct{}     `additionalProperties:"false"`
-	Target      string       `yaml:"target" enum:"csharp,go,java,mcp-typescript,php,python,ruby,swift,terraform,typescript,unity,postman" required:"true"`
+	Target      string       `yaml:"target" enum:"cli,csharp,go,java,mcp-typescript,php,python,ruby,swift,terraform,typescript,unity,postman" required:"true"`
 	Source      string       `yaml:"source" required:"true"`
 	Output      *string      `yaml:"output,omitempty"`
 	Publishing  *Publishing  `yaml:"publish,omitempty"`
@@ -53,6 +53,7 @@ type Publishing struct {
 	Java      *Java      `yaml:"java,omitempty" description:"Maven (Java) publishing configuration."`
 	RubyGems  *RubyGems  `yaml:"rubygems,omitempty" description:"Rubygems (Ruby) publishing configuration."`
 	Nuget     *Nuget     `yaml:"nuget,omitempty" description:"NuGet (C#) publishing configuration."`
+	CLI       *CLI       `yaml:"cli,omitempty" description:"CLI publishing configuration."`
 	Terraform *Terraform `yaml:"terraform,omitempty"`
 }
 
@@ -118,6 +119,11 @@ type RubyGems struct {
 type Nuget struct {
 	_      struct{} `additionalProperties:"false"`
 	APIKey string   `yaml:"apiKey" required:"true"`
+}
+
+type CLI struct {
+	GPGPrivateKey string `yaml:"gpgPrivateKey" required:"true"`
+	GPGPassPhrase string `yaml:"gpgPassPhrase" required:"true"`
 }
 
 type Terraform struct {
@@ -247,6 +253,16 @@ func (p Publishing) Validate(target string) error {
 				return fmt.Errorf("failed to validate nuget api key: %w", err)
 			}
 		}
+	case "cli":
+		if p.CLI != nil {
+			if err := validateSecret(p.CLI.GPGPrivateKey); err != nil {
+				return fmt.Errorf("failed to validate cli gpgPrivateKey: %w", err)
+			}
+
+			if err := validateSecret(p.CLI.GPGPassPhrase); err != nil {
+				return fmt.Errorf("failed to validate cli gpgPassPhrase: %w", err)
+			}
+		}
 	case "terraform":
 		if p.Terraform != nil {
 			if err := validateSecret(p.Terraform.GPGPrivateKey); err != nil {
@@ -293,6 +309,10 @@ func (p Publishing) IsPublished(target string) bool {
 		}
 	case "csharp":
 		if p.Nuget != nil && p.Nuget.APIKey != "" {
+			return true
+		}
+	case "cli":
+		if p.CLI != nil && p.CLI.GPGPrivateKey != "" && p.CLI.GPGPassPhrase != "" {
 			return true
 		}
 	case "terraform":

--- a/workflow/target_test.go
+++ b/workflow/target_test.go
@@ -36,6 +36,23 @@ func TestTarget_Validate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "cli target with publishing successfully validates",
+			args: args{
+				supportedLangs: []string{"cli"},
+				target: workflow.Target{
+					Target: "cli",
+					Source: "openapi.yaml",
+					Publishing: &workflow.Publishing{
+						CLI: &workflow.CLI{
+							GPGPrivateKey: "$CLI_GPG_PRIVATE_KEY",
+							GPGPassPhrase: "$CLI_GPG_PASSPHRASE",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "target that references a simple source successfully validates",
 			args: args{
 				supportedLangs: []string{"go"},
@@ -188,6 +205,23 @@ func TestTarget_Validate(t *testing.T) {
 				},
 			},
 			wantErr: fmt.Errorf("failed to validate publish: failed to validate npm token: secret must be a environment variable reference (ie $MY_SECRET)"),
+		},
+		{
+			name: "cli target with invalid publishing config fails",
+			args: args{
+				supportedLangs: []string{"cli"},
+				target: workflow.Target{
+					Target: "cli",
+					Source: "openapi.yaml",
+					Publishing: &workflow.Publishing{
+						CLI: &workflow.CLI{
+							GPGPrivateKey: "some-key",
+							GPGPassPhrase: "$CLI_GPG_PASSPHRASE",
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("failed to validate publish: failed to validate cli gpgPrivateKey: secret must be a environment variable reference (ie $MY_SECRET)"),
 		},
 		{
 			name: "target with complex publishing config fails when non-secret is missing",


### PR DESCRIPTION
## Summary
- add  to the supported workflow target enum
- add  config with GPG key/passphrase fields
- teach workflow validation and publish detection about CLI publishing
- regenerate 

## Why
 now adds CLI publish support, and  needs to recognize  plus a real publishing signal for CLI targets.
