### PR TITLE
feat: add ResponseEnvelopeNamingMar2026 fix flag

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -74,6 +74,7 @@ type Fixes struct {
 	SharedErrorComponentsApr2025         bool           `yaml:"sharedErrorComponentsApr2025" description:"Enables fixes that mean that when a component is used in both 2XX and 4XX responses, only the top level component will be duplicated to the errors scope as opposed to the entire component tree"`
 	SharedNestedComponentsJan2026        bool           `yaml:"sharedNestedComponentsJan2026" description:"Fixes component naming when the same schema is referenced in multiple places within nested structures, ensuring consistent naming based on the original component definition"`
 	NameOverrideFeb2026                  bool           `yaml:"nameOverrideFeb2026" description:"Prevents component-level x-speakeasy-name-override from affecting parent names when referencing schema via $ref or hoisting allOf extensions"`
+	ResponseEnvelopeNamingMar2026        bool           `yaml:"responseEnvelopeNamingMar2026" description:"Fixes response envelope type naming to not include group prefix from operationId, keeping type names stable across operationId renames"`
 	AdditionalProperties                 map[string]any `yaml:",inline" jsonschema:"-"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
 }
 
@@ -86,6 +87,11 @@ func (f *Fixes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if tmp.NameResolutionFeb2025 {
+		tmp.NameResolutionDec2023 = true
+	}
+
+	if tmp.ResponseEnvelopeNamingMar2026 {
+		tmp.NameResolutionFeb2025 = true
 		tmp.NameResolutionDec2023 = true
 	}
 

--- a/schemas/gen.config.schema.json
+++ b/schemas/gen.config.schema.json
@@ -42,10 +42,6 @@
           "description": "Prevents component-level x-speakeasy-name-override from affecting parent names when referencing schema via $ref or hoisting allOf extensions",
           "type": "boolean"
         },
-        "responseEnvelopeNamingMar2026": {
-          "description": "Fixes response envelope type naming to not include group prefix from operationId, keeping type names stable across operationId renames",
-          "type": "boolean"
-        },
         "nameResolutionDec2023": {
           "description": "Enables name resolution fixes from December 2023",
           "type": "boolean"
@@ -60,6 +56,10 @@
         },
         "requestResponseComponentNamesFeb2024": {
           "description": "Enables request and response component naming fixes from February 2024",
+          "type": "boolean"
+        },
+        "responseEnvelopeNamingMar2026": {
+          "description": "Fixes response envelope type naming to not include group prefix from operationId, keeping type names stable across operationId renames",
           "type": "boolean"
         },
         "securityFeb2025": {

--- a/schemas/gen.config.schema.json
+++ b/schemas/gen.config.schema.json
@@ -42,6 +42,10 @@
           "description": "Prevents component-level x-speakeasy-name-override from affecting parent names when referencing schema via $ref or hoisting allOf extensions",
           "type": "boolean"
         },
+        "responseEnvelopeNamingMar2026": {
+          "description": "Fixes response envelope type naming to not include group prefix from operationId, keeping type names stable across operationId renames",
+          "type": "boolean"
+        },
         "nameResolutionDec2023": {
           "description": "Enables name resolution fixes from December 2023",
           "type": "boolean"


### PR DESCRIPTION
## Summary
- Adds `ResponseEnvelopeNamingMar2026` to the `Fixes` struct in gen.yaml config
- When enabled, strips operation tag prefixes from response/request envelope type names so that operationId renames (e.g., `createApi` → `apis.createApi`) don't cause breaking type renames in generated SDKs
- Implies `NameResolutionFeb2025` (and transitively `NameResolutionDec2023`)
- Updates JSON schema

## Context
Pylon #10431 — Customer renamed operationIds to follow a `group.method` convention. This caused Go SDK response structs to be renamed (e.g., `CreateAPIResponse` → `ApisCreateAPIResponse`), which is breaking. TS/Python were unaffected because they use `flat` response format.

## Test plan
- [ ] Companion PR in `openapi-generation` uses this flag to gate the fix
- [ ] All Go primary tests pass with the fix enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)