### PR TITLE
chore: Revert generation.skipSteps configuration

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -159,22 +159,6 @@ func (p *PersistentEdits) ShouldCompilePristine() bool {
 	return *p.CompilePristine
 }
 
-type GenerationStep string
-
-const (
-	GenerationStepCompile GenerationStep = "compile"
-	GenerationStepLint    GenerationStep = "lint"
-)
-
-func (GenerationStep) PrepareJSONSchema(schema *jsg.Schema) error {
-	schema.Type = &jsg.Type{SimpleTypes: (*jsg.SimpleType)(pointer.From(jsg.String))}
-	schema.Enum = []any{
-		string(GenerationStepCompile),
-		string(GenerationStepLint),
-	}
-	return nil
-}
-
 type AllOfMergeStrategy string
 
 const (
@@ -214,7 +198,6 @@ type Generation struct {
 	Schemas                     Schemas            `yaml:"schemas"`
 	RequestBodyFieldName        string             `yaml:"requestBodyFieldName" description:"The name of the field to use for the request body in generated SDKs"`
 	VersioningStrategy          VersioningStrategy `yaml:"versioningStrategy,omitempty" enum:"automatic,manual" description:"Controls how SDK versions are determined. 'automatic' (default) bumps versions based on changes, 'manual' uses the version in gen.yaml as-is."`
-	SkipSteps                   []GenerationStep   `yaml:"skipSteps,omitempty" description:"A list of generation steps to skip. 'compile' skips code compilation and linting commands, 'lint' skips only the linting commands."`
 
 	// Mock server generation configuration.
 	MockServer *MockServer `yaml:"mockServer,omitempty"`

--- a/schemas/gen.config.schema.json
+++ b/schemas/gen.config.schema.json
@@ -127,13 +127,6 @@
           "description": "Skips the automatic addition of an error suffix to error types",
           "type": "boolean"
         },
-        "skipSteps": {
-          "description": "A list of generation steps to skip. 'compile' skips code compilation and linting commands, 'lint' skips only the linting commands.",
-          "items": {
-            "$ref": "#/$defs/SdkGenConfigGenerationStep"
-          },
-          "type": "array"
-        },
         "tests": {
           "$ref": "#/$defs/SdkGenConfigTests"
         },
@@ -154,13 +147,6 @@
         }
       },
       "type": "object"
-    },
-    "SdkGenConfigGenerationStep": {
-      "enum": [
-        "compile",
-        "lint"
-      ],
-      "type": "string"
     },
     "SdkGenConfigLanguageConfig": {
       "additionalProperties": true,


### PR DESCRIPTION
Reverts speakeasy-api/sdk-gen-config#118. This was not implemented downstream and will likely get implemented differently in the future, if at all.