### PR TITLE
feat: add EnumMemberCasingMar2026 fix flag

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -660,6 +660,12 @@ func GetGenerationDefaults(newSDK bool) []SDKGenConfigField {
 			Description:  pointer.From("Prevents component-level x-speakeasy-name-override from affecting parent names when referencing schema via $ref or hoisting allOf extensions"),
 		},
 		{
+			Name:         "fixes.enumMemberCasingMar2026",
+			Required:     false,
+			DefaultValue: ptr(newSDK),
+			Description:  pointer.From("Fixes enum member casing when SCREAMING_SNAKE_CASE values contain special characters like ampersands"),
+		},
+		{
 			Name:         "versioningStrategy",
 			Required:     false,
 			DefaultValue: ptr(VersioningStrategyAutomatic),

--- a/configuration.go
+++ b/configuration.go
@@ -74,6 +74,7 @@ type Fixes struct {
 	SharedErrorComponentsApr2025         bool           `yaml:"sharedErrorComponentsApr2025" description:"Enables fixes that mean that when a component is used in both 2XX and 4XX responses, only the top level component will be duplicated to the errors scope as opposed to the entire component tree"`
 	SharedNestedComponentsJan2026        bool           `yaml:"sharedNestedComponentsJan2026" description:"Fixes component naming when the same schema is referenced in multiple places within nested structures, ensuring consistent naming based on the original component definition"`
 	NameOverrideFeb2026                  bool           `yaml:"nameOverrideFeb2026" description:"Prevents component-level x-speakeasy-name-override from affecting parent names when referencing schema via $ref or hoisting allOf extensions"`
+	EnumMemberCasingMar2026              bool           `yaml:"enumMemberCasingMar2026" description:"Fixes enum member casing when SCREAMING_SNAKE_CASE values contain special characters like ampersands"`
 	AdditionalProperties                 map[string]any `yaml:",inline" jsonschema:"-"` // Captures any additional properties that are not explicitly defined for backwards/forwards compatibility
 }
 


### PR DESCRIPTION
## Summary
Adds `EnumMemberCasingMar2026` bool field to the `Fixes` struct so that the enum member casing fix for SCREAMING_SNAKE_CASE values with special characters (GEN-2737) can be gated behind a gen.yaml flag.

Fixes GEN-2737

## Test plan
- [x] Field properly deserializes from gen.yaml
- [x] openapi-generation compiles with local replace directive
- [x] Review SDKs regenerated with correct enum names

🤖 Generated with [Claude Code](https://claude.com/claude-code)